### PR TITLE
Add ability to define a debugRegex

### DIFF
--- a/src/main/java/de/tschumacher/mandrillservice/configuration/MandrillServiceConfig.java
+++ b/src/main/java/de/tschumacher/mandrillservice/configuration/MandrillServiceConfig.java
@@ -19,6 +19,7 @@ public class MandrillServiceConfig {
   private final String mandrillKey;
   private final boolean isDebug;
   private final String debugMail;
+  private final String debugRegex;
   private final String defaultFromMail;
   private final String defaultFromName;
 
@@ -32,6 +33,10 @@ public class MandrillServiceConfig {
 
   public String getDebugMail() {
     return debugMail;
+  }
+
+  public String getDebugRegex() {
+    return debugRegex;
   }
 
   public String getDefaultFromMail() {
@@ -50,6 +55,7 @@ public class MandrillServiceConfig {
     this.mandrillKey = builder.mandrillKey;
     this.isDebug = builder.isDebug;
     this.debugMail = builder.debugMail;
+    this.debugRegex = builder.debugRegex;
     this.defaultFromMail = builder.defaultFromMail;
     this.defaultFromName = builder.defaultFromName;
   }
@@ -59,6 +65,7 @@ public class MandrillServiceConfig {
     private String mandrillKey;
     private boolean isDebug;
     private String debugMail;
+    private String debugRegex;
     private String defaultFromMail;
     private String defaultFromName;
 
@@ -74,6 +81,11 @@ public class MandrillServiceConfig {
 
     public Builder withDebugMail(String debugMail) {
       this.debugMail = debugMail;
+      return this;
+    }
+
+    public Builder withDebugRegex(String debugRegex) {
+      this.debugRegex = debugRegex;
       return this;
     }
 


### PR DESCRIPTION
This change allows finer control about recipients. If the debug flag is activated, all recipients would be replaced by the debug email address.

Now one is able to set up exclusions by using a new property called `debugRegex`. All recipients matching this regex will *not* be replaced by the debug email address regardless of the debug flag.

This is especially useful for test environments where you want emails to be sent to company email addresses but not others.

`DefaultMandrillService` is getting quite complex. I think, we should refactor it in the future and split it up in multiple classes.